### PR TITLE
Release 0 0 22

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ html_show_copyright = False
 author = 'Christiam Camacho'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.21'
+release = '0.0.22'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -478,25 +478,23 @@ Input/output configuration options
     [blast]
     queries = /home/${USER}/blast-queries.tar.gz
 
-.. _elb_results_bucket:
+.. _elb_results:
 
-``Results bucket`` 
-^^^^^^^^^^^^^^^^^^
+``Results`` 
+^^^^^^^^^^^
 
-    GCS or AWS S3 bucket URI where to save the output from ElasticBLAST. 
+    GCS or AWS S3 bucket URI where to save the results from ElasticBLAST. 
 
     **Note**: This bucket *must* exist prior to invoking ElasticBLAST and it
     *must* include the ``gs://`` or ``s3://`` prefix.
 
-    * Default: ``gs://elasticblast-${USER}`` for GCP; ``s3://elasticblast-${USER}`` for AWS.
+    * Default: None
     * Values: String
-
-    Also supported via the environment variable: ``ELB_RESULTS_BUCKET``.
 
 .. code-block::
 
     [blast]
-    results-bucket = ${YOUR_RESULTS_BUCKET}
+    results = ${YOUR_RESULTS_BUCKET}
 
 Timeout configuration options
 -----------------------------

--- a/docs/source/issues.rst
+++ b/docs/source/issues.rst
@@ -45,18 +45,22 @@ ElasticBLAST allocates a :ref:`compute cluster <elb_cluster_name>` in the cloud 
 Files left in cloud storage
 ---------------------------
 
-ElasticBLAST uses cloud storage to temporally store query sequences and internal logs and metadata so that they are easily accessible during its operation. Sometimes deleting these files after the search is not successful. To double check and delete them, please run the commands below:
+ElasticBLAST uses cloud storage to temporally store query sequences and
+internal logs and metadata so that they are easily accessible during its
+operation. Sometimes deleting these files after the search is not successful.
+To double check and delete them, please run the commands below. 
+``ELB_RESULTS`` below represents the location where your results are stored.
 
 .. code-block:: bash
 
-   gsutil ls gs://${ELB_RESULTS_BUCKET}/query_batches  # to list query files
-   gsutil -m rm gs://${ELB_RESULTS_BUCKET}/query_batches/*  # to delete query files
+   gsutil ls gs://${ELB_RESULTS}/query_batches  # to list query files
+   gsutil -m rm gs://${ELB_RESULTS}/query_batches/*  # to delete query files
 
-   gsutil ls gs://${ELB_RESULTS_BUCKET}/logs  # to list log files
-   gsutil -m rm gs://${ELB_RESULTS_BUCKET}/logs/*  # to delete log files
+   gsutil ls gs://${ELB_RESULTS}/logs  # to list log files
+   gsutil -m rm gs://${ELB_RESULTS}/logs/*  # to delete log files
 
-   gsutil ls gs://${ELB_RESULTS_BUCKET}/metadata  # list metadata files
-   gsutil -m rm gs://${ELB_RESULTS_BUCKET}/logs/*  # to delete metadata files
+   gsutil ls gs://${ELB_RESULTS}/metadata  # list metadata files
+   gsutil -m rm gs://${ELB_RESULTS}/logs/*  # to delete metadata files
 
 
 .. _early_shutdown:

--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -70,7 +70,7 @@ The minimal configuration requires:
 #. :ref:`AWS region <elb_aws_region>` to run ElasticBLAST on (``us-east-1`` recommended, see :ref:`AWS configuration <aws_conf>` for additional details),
 #. :ref:`query sequences <elb_queries>` in a single file or tarball, 
 
-#. a :ref:`cloud storage bucket for results <elb_results_bucket>`. This value must start with ``s3://``.
+#. a :ref:`cloud storage bucket for results <elb_results>`. This value must start with ``s3://`` and _uniquely_ identifies your ElasticBLAST search. **Please keept track of this**.
 
 #. basic BLAST parameters (:ref:`program <elb_blast_program>` and :ref:`database <elb_db>`), and
 
@@ -95,7 +95,7 @@ They can be provided on a standard ini configuration file, e.g.:
     program = blastp
     db = swissprot
     queries = s3://elasticblast-test/queries/BDQE01.1.fsa_aa
-    results-bucket = ${YOUR_RESULTS_BUCKET}
+    results = ${YOUR_RESULTS_BUCKET}
     options = -task blastp-fast -evalue 0.01 -outfmt 7 
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -44,7 +44,7 @@ The minimal configuration requires:
 
 #. :ref:`query sequences <elb_queries>` in a single file or tarball, 
 
-#. a :ref:`cloud storage bucket for results <elb_results_bucket>`. This value must start with ``gs://``.
+#. a :ref:`cloud storage bucket for results <elb_results>`. This value must start with ``gs://`` and _uniquely_ identifies your ElasticBLAST search. **Please keept track of this**.
 
 #. basic BLAST parameters (:ref:`program <elb_blast_program>` and :ref:`database <elb_db>`), and
 
@@ -70,7 +70,7 @@ They can be provided on a standard ini configuration file, e.g.:
     program = blastp
     db = nr
     queries = gs://elastic-blast-samples/queries/protein/BDQE01.1.fsa_aa
-    results-bucket = ${YOUR_RESULTS_BUCKET}
+    results = ${YOUR_RESULTS_BUCKET}
     options = -task blastp-fast -evalue 0.01 -outfmt 7 
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.

--- a/docs/source/taxid-filtering.rst
+++ b/docs/source/taxid-filtering.rst
@@ -34,5 +34,5 @@ Below is an example ElasticBLAST configuration file that limits search results b
     program = blastn
     db = pdbnt
     queries = s3://elasticblast-test/queries/RFQT01.1.fsa_nt.gz
-    results-bucket = ${YOUR_RESULTS_BUCKET}
+    results = ${YOUR_RESULTS_BUCKET}
     options = -outfmt 7 -taxids 1866885,1804623

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -84,7 +84,7 @@ Things to check:
 
    gcloud config get-value account
 
-* The bucket URI (in the "results-bucket" field of the config file) starts with ``gs://``.  For example, the bucket URI should be ``gs://sarahtest`` but instead you have "sarahtest".
+* The bucket URI (in the "results" field of the config file) starts with ``gs://``.  For example, the bucket URI should be ``gs://sarahtest`` but instead you have "sarahtest".
 
 * The bucket URI is correct and you have permission to write to it.  The GCP page on bucket permissions is at https://cloud.google.com/storage/docs/gsutil/commands/acl but it is probably easiest to try and copy a file into your bucket with:
 


### PR DESCRIPTION
Documentation changes for release 0.0.22:

* taxonomic filtering on BLASTDBs
* results-bucket renamed to results
* results uniquely identifies ElasticBLAST searches to support concurrent searches
* There is no default value for results anymore
