### PR TITLE
Use num-cpus parameter in config examples

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -89,6 +89,7 @@ They can be provided on a standard ini configuration file, e.g.:
 
     [cluster]
     machine-type = m5.8xlarge
+    num-cpus = 30
     num-nodes = 1
 
     [blast]

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -64,6 +64,7 @@ They can be provided on a standard ini configuration file, e.g.:
     gcp-zone = us-east4-b
 
     [cluster]
+    num-cpus = 30
     num-nodes = 3
 
     [blast]


### PR DESCRIPTION
After the fix for EB-908, the default number of CPUs is set to 1.