### PR TITLE
Fix to command to retrieve EC2 instances for the relevant ElasticBLAST run

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -195,13 +195,14 @@ It is also recommended each time you start a new ElasticBLAST search.
 The delete command will take a few minutes to run as it needs to manage multiple cloud resources.
 
 After the ``elastic-blast delete`` command returns, you may verify that your
-cloud resources have been deleted by running the command below. Its output will
-show the EC2 instance IDs ``elastic-blast`` created on your behalf that are
+cloud resources have been deleted by running the command below. The command requires that the
+``${ELB_RESULTS}`` environment variable be set to the value of ``${YOUR_RESULTS_BUCKET}``.
+Its output will show the EC2 instance IDs ``elastic-blast`` created on your behalf that are
 still in the ``running`` state.
 
 .. code-block:: bash
 
-  aws ec2 describe-instances --filter Name=tag:billingcode,Values=elastic-blast Name=tag:Owner,Values=${USER} --query "Reservations[*].Instances[?State.Name=='running'].InstanceId" --output text 
+  aws ec2 describe-instances --filter Name=tag:billingcode,Values=elastic-blast Name=tag:Name,Values=elasticblast-${USER}-$(echo -n ${YOUR_RESULTS_BUCKET} | md5sum | cut -b-9) --query "Reservations[*].Instances[?State.Name=='running'].InstanceId" --output text 
 
 
 .. _aws_conf:


### PR DESCRIPTION
This is to address Greg's feedback from PR #37.

Sample output comparing the proposed changes:

```bash
$ aws ec2 describe-instances --filter Name=tag:billingcode,Values=elastic-blast Name=tag:Name,Values=elasticblast-${USER}-$(echo -n ${ELB_RESULTS} | md5sum | cut -b-9) --query "Reservations[*].Instances[?State.Name=='running'].InstanceId" --output text
i-0d47b19abdbff2ff9     i-05865ff25ea091629     i-0a30ffac451f927ed     i-048fe06eb30f8d380     i-02cf22f61f50812bd
i-06b034619644d23fb     i-0b9aaa86b21c62a71     i-045203867e4c99105     i-043af10abce82d11c     i-0eb3ee34090c8a080
$ aws ec2 describe-instances --filter Name=tag:billingcode,Values=elastic-blast Name=tag:Owner,Values=${USER} --query "Reservations[*].Instances[?State.Name=='running'].InstanceId" --output text
i-0d47b19abdbff2ff9     i-05865ff25ea091629     i-0a30ffac451f927ed     i-048fe06eb30f8d380     i-02cf22f61f50812bd
i-06b034619644d23fb     i-0b9aaa86b21c62a71     i-045203867e4c99105     i-043af10abce82d11c     i-0eb3ee34090c8a080
17:21:21 camacho@blastdev21 /export/home/camacho/elastic-blast-nopal-blastp (develop)$
```