### PR TITLE
Add warning for GCP resource leak

### DIFF
--- a/docs/source/gcp-issues.rst
+++ b/docs/source/gcp-issues.rst
@@ -23,12 +23,7 @@
 Known issues on GCP
 ===================
 
-.. _elb_batch_len_setting:
-
-Batch length setting
---------------------
-
-The value of :ref:`ELB_BATCH_LEN` greatly affects performance. The defaults are reasonable, but may not be optimal in some cases. We are in the process of determining better values for various programs and use cases.
+**IMPORTANT:** The current GCP implementation can leak cloud resources, potentially resulting in excess user charges. We are working to update the code and expect a fix soon. In the interim, we suggest using our AWS implementation, or for those who wish to use GCP, we have provided a workaround that, when applied, addresses this issue and eliminates the risk of excess user charges. For more information, see items on this page. (Message date: July 21, 2021)
 
 
 .. _pd_leak:
@@ -36,10 +31,7 @@ The value of :ref:`ELB_BATCH_LEN` greatly affects performance. The defaults are 
 Persistent disk not properly deleted
 ------------------------------------
 
-As part of its normal operation ElasticBLAST starts a
-:ref:`persistent disk <elb_pd_size>` and under some circumstances it
-is not properly deleted. To double check and delete it, please run the commands
-below accordingly:
+As part of its normal operation ElasticBLAST starts a :ref:`persistent disk <elb_pd_size>`. We find that under some circumstances this disk is not properly deleted and will lead to excess charges for the user. We are working to update the code and expect a fix soon. In the interim, to delete the disk and avoid charges, run the following commands (Message date: July 21, 2021).
 
 .. code-block:: bash
 
@@ -81,6 +73,13 @@ To double check and delete them, please run the commands below.
 
    gsutil ls gs://${ELB_RESULTS}/metadata  # list metadata files
    gsutil -m rm gs://${ELB_RESULTS}/logs/*  # to delete metadata files
+
+.. _elb_batch_len_setting:
+
+Batch length setting
+--------------------
+
+The value of :ref:`ELB_BATCH_LEN` greatly affects performance. The defaults are reasonable, but may not be optimal in some cases. We are in the process of determining better values for various programs and use cases.
 
 
 .. _too_many_jobs:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,11 +30,13 @@ ElasticBLAST speeds up your work by distributing your searches across multiple c
 
 The National Center for Biotechnology Information (`NCBI <https://www.ncbi.nlm.nih.gov/>`_), part of the National Library of Medicine at the NIH, develops and maintains ElasticBLAST.
 
-It runs on AWS and GCP and requires that you have an account on one of those cloud providers.
+**ElasticBLAST status:** alpha
 
-Currently, ElasticBLAST is alpha software.
+**Platforms available:** AWS, GCP (account required)
 
-To get started, go to the :ref:`overview`.
+**Bug affecting GCP implementation:** The current GCP implementation can leak cloud resources, potentially resulting in excess user charges. We are working to update the code and expect a fix soon. In the interim, we suggest using our AWS implementation, or for those who wish to use GCP, we have provided a workaround that, when applied, addresses this issue and eliminates the risk of excess user charges. For more information, see :ref:`pd_leak`. (Message date: July 21, 2021)
+
+**Getting started:** Go to the :ref:`overview`.
 
 
      

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -79,7 +79,8 @@ AWS and GCP have programs to award Cloud Credits to researchers at accredited re
 * https://edu.google.com/programs/credits/research
 
 Both cloud service providers also have Free Tiers:  
+
 * https://aws.amazon.com/free
 * https://cloud.google.com/free
 
-While these are a good way to learn about the cloud, they may be too limited for you to effectively use ElasticBLAST.
+While the Free Tiers are a good way to learn about the cloud, they may be too limited for you to effectively use ElasticBLAST.


### PR DESCRIPTION
Added warning for GCP resource leak on landing page as well as GCP-issues.  Also, minor fix in overview.rst for free tiers.