### PR TITLE
Invoke yum install with -y

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -44,7 +44,7 @@ Copy and paste the commands below at the CloudShell prompt to install ElasticBLA
 
 .. code-block:: shell
 
-    sudo yum install python3-wheel
+    sudo yum install -y python3-wheel
     sudo pip3 install elastic-blast
 
 

--- a/docs/source/tutorials/pypi-install.rst
+++ b/docs/source/tutorials/pypi-install.rst
@@ -69,4 +69,4 @@ If you run into installation problems on AWS, please run the command below and k
 
 .. code-block:: bash
 
-    sudo yum install python3-wheel
+    sudo yum install -y python3-wheel


### PR DESCRIPTION
This pull request changes the documentation to suggest invoking `yum install -y` so the user doesn't have to confirm the installation.
