### PR TITLE
Suggest to use all lower case letters for bucket name

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -68,7 +68,7 @@ Set up an output bucket (if one doesn't exist)
 
     aws s3 ls s3://elasticblast-YOURNAME || aws s3 mb s3://elasticblast-YOURNAME
 
-Substitute your name for "YOURNAME."
+Substitute your name for "YOURNAME" using all lower case letters.
 
 
 Configure ElasticBLAST


### PR DESCRIPTION
Suggest using lower case letters in AWS bucket name to prevent errors.
