### PR TITLE
Add settings to ensure better performance in AWS quickstart

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -88,11 +88,14 @@ Start by, copying the configuration file shown below.  Using an editor, write th
     aws-region = us-east-1
 
     [cluster]
+    machine-type = m5.8xlarge
+    num-cpus = 16
     num-nodes = 2
 
     [blast]
     program = blastp
     db = refseq_protein
+    mem-limit = 61G
     queries = s3://elasticblast-test/queries/BDQA01.1.fsa_aa
     results = s3://elasticblast-YOURNAME/results/BDQA
     options = -task blastp-fast -evalue 0.01 -outfmt "7 std sskingdoms ssciname"  


### PR DESCRIPTION
This is to ensure the AWS quickstart example runs as best at it possible can.
