### PR TITLE
Override owner label in quickstart config file

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -91,6 +91,7 @@ Start by, copying the configuration file shown below.  Using an editor, write th
     machine-type = m5.8xlarge
     num-cpus = 16
     num-nodes = 2
+    labels = owner=YOURNAME
 
     [blast]
     program = blastp
@@ -108,7 +109,7 @@ This configuration file specifies two AWS instances, specified by "num-nodes", f
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.
 
-There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket.
+There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``YOURNAME`` with your name in all lowercase characters.
 
 This search should take about 30 minutes to run and cost less than $3.
 

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -108,7 +108,7 @@ This configuration file specifies two GCP instances, specified by "num-nodes", f
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.
 
-There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``YOURNAME`` with your name in all lowercase characters.
+There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``$USER`` with your name in all lowercase characters.
 
 This search should take about 30 minutes to run and cost less than $3.  
 

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -91,6 +91,7 @@ Start by copying the configuration file shown below.  Using an editor, write thi
 
     [cluster]
     num-nodes = 2
+    labels = owner=${USER}
 
     [blast]
     program = blastp
@@ -107,7 +108,7 @@ This configuration file specifies two GCP instances, specified by "num-nodes", f
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.
 
-There is no need to change any lines in the configuration file (BDQA.ini) other than the gcp-project and the results.  
+There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``YOURNAME`` with your name in all lowercase characters.
 
 This search should take about 30 minutes to run and cost less than $3.  
 


### PR DESCRIPTION
This change overrides the `owner` label in the quick start configuration file to facilitate tracking searches in a CloudShell environment.