### PR TITLE
add pypi bioconda logos

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-sphinx==3.0.1
+sphinx==4.2.0
 sphinx-copybutton
 recommonmark
-docutils==0.12

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,9 @@ exclude_patterns = []
 
 # https://www.sphinx-doc.org/en/master/usage/configuration.html?highlight=linkcheck#options-for-the-linkcheck-builder
 #linkcheck_ignore = [r'blast_plus_docs']
-linkcheck_ignore = [r'https://github.com/ncbi/blast_plus_docs/blob/master/README.md#blast-databases']
+linkcheck_ignore = [r'https://github.com/ncbi/blast_plus_docs/blob/master/README.md#blast-databases',
+        r'tutorials/pypi-install.html',
+        r'tutorials/conda-install.html']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,20 @@ The National Center for Biotechnology Information (`NCBI <https://www.ncbi.nlm.n
 
 **Getting started:** Go to the :ref:`overview`.
 
+**Availability:** 
+
+.. 2021-11-10 The image :target: option cannot be used with :ref: :(
+.. https://stackoverflow.com/questions/32340062/sphinx-restructuredtext-how-to-link-an-image-to-a-document-page
+
+.. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/PyPI_logo.svg/248px-PyPI_logo.svg.png
+   :name: pypi icon
+   :alt: PyPI icon
+   :target: tutorials/pypi-install.html
+
+.. image:: https://bioconda.github.io/_images/bioconda.png
+   :name: bioconda icon
+   :alt: Bioconda icon
+   :target: tutorials/conda-install.html
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,14 +42,35 @@ The National Center for Biotechnology Information (`NCBI <https://www.ncbi.nlm.n
 .. https://stackoverflow.com/questions/32340062/sphinx-restructuredtext-how-to-link-an-image-to-a-document-page
 
 .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/PyPI_logo.svg/248px-PyPI_logo.svg.png
-   :name: pypi icon
-   :alt: PyPI icon
-   :target: tutorials/pypi-install.html
+  :name: pypi icon
+  :alt: PyPI icon
+  :target: tutorials/pypi-install.html
+  :height: 100px
+  :width: 30%
 
 .. image:: https://bioconda.github.io/_images/bioconda.png
-   :name: bioconda icon
-   :alt: Bioconda icon
-   :target: tutorials/conda-install.html
+  :name: bioconda icon
+  :alt: Bioconda icon
+  :target: tutorials/conda-install.html
+  :height: 40px
+  :width: 50%
+
+.. .. hlist::
+..    :columns: 2
+..
+..   .. image:: https://bioconda.github.io/_images/bioconda.png
+..      :name: bioconda icon
+..      :alt: Bioconda icon
+..      :target: tutorials/conda-install.html
+..      :height: 40px
+..      :width: 60%
+..   
+..   .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/PyPI_logo.svg/248px-PyPI_logo.svg.png
+..      :name: pypi icon
+..      :alt: PyPI icon
+..      :target: tutorials/pypi-install.html
+..      :height: 90px
+..      :width: 60%
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This pull request updates the ElasticBLAST documentation landing page, addition the section "availability" as shown below. Both icons are hyperlinks to ElasticBLAST's documentation on how to install via PyPI and BioConda.

<img width="1047" alt="Screen Shot 2021-11-10 at 8 53 45 AM" src="https://user-images.githubusercontent.com/736979/141128964-9891bb1a-9d5b-4f81-97e1-10b4bd6c8cc5.png">
