### PR TITLE
Add link about performance degradation due to a small pd-size

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -330,7 +330,9 @@ Cluster configuration
 
     Format as <number> immediately followed by G for gigabytes, M for megabytes.
 
-    **Note**: Smaller disks than ``1000G`` result in performance degradation in GCP.
+    **Note**: ElasticBLAST uses ``pd-standard`` block storage by default. Per the
+    `GCP documentation on block storage <https://cloud.google.com/compute/docs/disks/performance#performance_by_disk_size>`_,
+    smaller disks than ``1000G`` result in performance degradation for ElasticBLAST in GCP.
 
     * Default: ``3000G`` for GCP, ``1000G`` for AWS.
     * Values: String
@@ -338,7 +340,7 @@ Cluster configuration
 .. code-block::
 
     [cluster]
-    pd-size = 1000G
+    pd-size = 3000G
 
 .. _elb_labels:
 


### PR DESCRIPTION
This change adds a link to https://cloud.google.com/compute/docs/disks/performance#performance_by_disk_size . The changed text is highlighted in the screenshot below for your convenience:

<img width="1082" alt="Screen Shot 2021-12-13 at 1 38 31 PM" src="https://user-images.githubusercontent.com/736979/145869236-5ea0f2cd-3b10-408c-9158-6c0646a4acbc.png">
