### PR TITLE
Changes for consistency with beta release, JIRA:EB-1423

### DIFF
--- a/docs/source/aws-issues.rst
+++ b/docs/source/aws-issues.rst
@@ -23,14 +23,6 @@
 Known issues on AWS
 ===================
 
-.. _elb_batch_len_setting_aws:
-
-Batch length setting
---------------------
-
-The value of :ref:`ELB_BATCH_LEN` greatly affects performance. The defaults are reasonable, but may not be optimal in some cases. We are in the process of determining better values for various programs and use cases.
-
-
 .. _elb_delete_failure:
 
 ElasticBLAST delete failures

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -283,22 +283,11 @@ Cluster configuration
 
     Type of GCP or AWS machine to start as worker node(s). 
 
+    **WARNING**: ElasticBLAST will select a machine type for you with sufficient RAM to hold your database in memory if you search an NCBI provided database or provided metadata for a database you provide (see :ref:`tutorial_create_blastdb_metadata`).  This is the recommended way to use ElasticBLAST.  Specifiying the machine type will override this feature, and you need to be sure that your machine type has sufficient memory to hold you database.  
+
     **NOTE**: The machine's available RAM should be large enough to contain the sequences in the database (one byte per residue or one byte per four bases) plus ~20%.
 
-    * Default: ``n1-standard-32`` for GCP, ``m5.8xlarge`` for AWS.
-    * The default machines have 32 cores and about 120GB of RAM.
     * Values: String, see `GCP machine types <https://cloud.google.com/compute/docs/machine-types>`_ or `AWS instance types <https://aws.amazon.com/ec2/instance-types>`_ accordingly.
-
-    **Note**: ElasticBLAST on AWS supports the specification of an ``optimal``
-    instance type. 
-
-    * This is an *experimental* feature. 
-    * **Requires** the specification of the :ref:`memory limit <elb_mem_limit>` to use per BLAST job.
-    * Benefits include: greater breadth of available AWS instance types
-      (beneficial for getting spot instances) and freeing the end user from
-      having to match instance types to their BLAST search. 
-    * Potential downside: AWS Batch does not guarantee optimal performance of
-      the instances it selects.
 
 .. code-block::
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -283,10 +283,13 @@ Cluster configuration
 
     Type of GCP or AWS machine to start as worker node(s). 
 
-    **WARNING**: ElasticBLAST will select a machine type for you with sufficient RAM to hold your database in memory if you search an NCBI provided database or provided metadata for a database you provide (see :ref:`tutorial_create_blastdb_metadata`).  This is the recommended way to use ElasticBLAST.  Specifiying the machine type will override this feature, and you need to be sure that your machine type has sufficient memory to hold you database.  
+    **WARNING**: ElasticBLAST will select a machine type for you with sufficient RAM to hold your database in memory if you search an NCBI provided database or provide metadata for your custom database (see :ref:`tutorial_create_blastdb_metadata`).  This is the recommended way to use ElasticBLAST.  Specifiying the machine type will override this feature, and you need to be sure that your machine type has sufficient memory to hold you database.  
 
     **NOTE**: The machine's available RAM should be large enough to contain the sequences in the database (one byte per residue or one byte per four bases) plus ~20%.
 
+    * Default: ``n1-standard-32`` for GCP, ``m5.8xlarge`` for AWS.
+    * The default machines have 32 cores and about 120GB of RAM.
+    * These default values only apply if you use a custom database and do not provide metadata.
     * Values: String, see `GCP machine types <https://cloud.google.com/compute/docs/machine-types>`_ or `AWS instance types <https://aws.amazon.com/ec2/instance-types>`_ accordingly.
 
 .. code-block::

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -287,7 +287,7 @@ Cluster configuration
 
     **NOTE**: The machine's available RAM should be large enough to contain the sequences in the database (one byte per residue or one byte per four bases) plus ~20%.
 
-    * Default: ``n1-standard-32`` for GCP, ``m5.8xlarge`` for AWS.
+    * Default: ``n1-highmem-32`` for GCP, ``m5.8xlarge`` for AWS.
     * The default machines have 32 cores and about 120GB of RAM.
     * These default values only apply if you use a custom database and do not provide metadata.
     * Values: String, see `GCP machine types <https://cloud.google.com/compute/docs/machine-types>`_ or `AWS instance types <https://aws.amazon.com/ec2/instance-types>`_ accordingly.

--- a/docs/source/gcp-issues.rst
+++ b/docs/source/gcp-issues.rst
@@ -45,14 +45,6 @@ To double check and delete them, please run the commands below.
    gsutil ls gs://${ELB_RESULTS}/metadata  # list metadata files
    gsutil -m rm gs://${ELB_RESULTS}/logs/*  # to delete metadata files
 
-.. _elb_batch_len_setting:
-
-Batch length setting
---------------------
-
-The value of :ref:`ELB_BATCH_LEN` greatly affects performance. The defaults are reasonable, but may not be optimal in some cases. We are in the process of determining better values for various programs and use cases.
-
-
 .. _too_many_jobs:
 
 Too many query batches leads to failed execution

--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -98,15 +98,16 @@ Start by, copying the configuration file shown below.  Using an editor, write th
     results = s3://elasticblast-YOURNAME/results/BDQA
     options = -task blastp-fast -evalue 0.01 -outfmt "7 std sskingdoms ssciname"  
 
-You will need to edit the file to provide your results bucket. For your results bucket, you should append "/results/BDQA" to your output bucket.  If you created it with the s3 command above, it would be as shown in the configuration file once you replace YOURNAME with your real name.
+You will need to make the following changes to the configuration file:
 
-ElasticBLAST will place your results at s3://elasticblast-YOURNAME/results/BDQA.  For your next search, you should use a different token than BDQA, otherwise your new results will be placed at the same location, possibly overwriting your first set of results.
+#. Replace YOURNAME on the "label" line with your name using all lower case letters.
+#. Replace YOURNAME on the "results" line with your name using all lower case letters.
+
+ElasticBLAST will place your results at gs://elasticblast-YOURNAME/results/BDQA.  For your next search, you should use a different token than BDQA or remove those results, otherwise elastic-blast will refuse to run as it would overwrite your old results.
 
 This configuration file specifies two AWS instances, specified by "num-nodes", for your search.  The BLASTP program searches proteins from the BDQA WGS project (obtained from a public cloud bucket) against the refseq_protein database.
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.
-
-There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``YOURNAME`` with your name in all lowercase characters.
 
 This search should take about 30 minutes to run and cost less than $3.
 

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -85,30 +85,34 @@ Start by copying the configuration file shown below.  Using an editor, write thi
     :linenos:
 
     [cloud-provider]
-    gcp-project = ${YOUR_GCP_PROJECT_ID}
+    gcp-project = YOUR_GCP_PROJECT_ID
     gcp-region = us-east4   
     gcp-zone = us-east4-b
 
     [cluster]
     num-nodes = 2
-    labels = owner=${USER}
+    labels = owner=USER
 
     [blast]
     program = blastp
     db = refseq_protein
     queries = gs://elastic-blast-samples/queries/protein/BDQA01.1.fsa_aa
-    results = gs://elasticblast-${USER}/results/BDQA
+    results = gs://elasticblast-USER/results/BDQA
     options = -task blastp-fast -evalue 0.01 -outfmt "7 std sskingdoms ssciname" 
 
-You will need to edit the file to provide a GCP Project ID and your results bucket. Read about how to identify your `GCP project <https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects>`_.  For your results bucket, you should append "/results/BDQA" to your output bucket.  If you created it with the gsutil command above, it would be as shown in the configuration file above.  
+You will need to make the following changes to the configuration file:
 
-ElasticBLAST will place your results at gs://elasticblast-${USER}/results/BDQA.  For your next search, you should use a different token than BDQA, otherwise your new results will be placed at the same location, possibly overwriting your first set of results.
+#. Replace YOUR_GCP_PROJECT_ID with your actual GCP Project ID.  Read how to identify your `GCP project <https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects>`_.  
+#. Replace USER on the "label" line with your actual username using all lower case letters (value of ${USER}).
+#. Replace USER on the "results" line with your actual username using all lower case letters (value of ${USER}).
+
+If you created your results bucket with the gsutil command above, it will be as shown in the configuration file above.  
+
+ElasticBLAST will place your results at gs://elasticblast-${USER}/results/BDQA.  For your next search, you should use a different token than BDQA or remove those results, otherwise elastic-blast will refuse to run as it would overwrite your old results.  
 
 This configuration file specifies two GCP instances, specified by "num-nodes", for your search.  The BLASTP program searches proteins from the BDQA WGS project (obtained from a cloud bucket) against the refseq_protein database.
 
 In addition to the minimal parameters, the configuration file above includes some BLAST options.
-
-There is no need to change any lines in the configuration file (BDQA.ini) other than the results bucket and the ``owner`` label (i.e.: replace ``$USER`` with your name in all lowercase characters.
 
 This search should take about 30 minutes to run and cost less than $3.  
 

--- a/docs/source/taxid-filtering.rst
+++ b/docs/source/taxid-filtering.rst
@@ -47,7 +47,6 @@ Below is an example ElasticBLAST configuration file that limits search results b
     aws-region = us-east-1
 
     [cluster]
-    machine-type = m5.8xlarge
     num-nodes = 1
 
     [blast]

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -56,8 +56,10 @@ may need or want to make:
     though you may want to change the number of machines (``num-nodes``).  In
     this section, you can also add a ``use-preemptible = yes`` key/value pair to
     indicate that you want to use a less expensive preemptible (GCP) or spot
-    (AWS) instance. See :ref:`elb_use_preemptible` for details.  You can also
-    change the ``machine-type`` in this section.  See :ref:`elb_machine_type` for
+    (AWS) instance. See :ref:`elb_use_preemptible` for details.  ElasticBLAST
+    will select an appropriate machine type with sufficient memory for your database.
+    You may override this feature and specify a ``machine-type`` in this section, but that
+    is not recommended.  See :ref:`elb_machine_type` for
     information on the default machine types and how to select a different
     machine type.
 

--- a/docs/source/tutorials/large-megablast.rst
+++ b/docs/source/tutorials/large-megablast.rst
@@ -39,7 +39,6 @@ The instructions below assume the configuration file is named hepatitis.ini.  If
     num-nodes = 4
 
     [blast]
-    mem-limit = 61G
     program = blastn 
     db = nt
     #queries = gs://elastic-blast-samples/queries/tests/hepatitis.fsa


### PR DESCRIPTION
- Replaced ${YOUR_GCP_PROJECT_ID} and ${USER} in GCP quickstart config file with YOUR_GCP_PROJECT_ID and USER
- Added numbered list of needed changes to config file in both quickstarts
- Removed warning about batch length settings in both known issue pages.
- Modified machine type configuration entry to advise against specifying machine type
- Removed mem-limit from config file for "MegaBLAST on a large nucleotide set"