### PR TITLE
Provide non-sudo installation instructions in quickstarts

### DIFF
--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -43,8 +43,18 @@ In order to complete this quickstart, you will need to be familiar with the AWS 
 Get ElasticBLAST
 ----------------
 
-Please follow the instructions on :ref:`tutorial_pypi` or
-:ref:`tutorial_conda`. Following these instructions will add ``elastic-blast``
+Copy and paste the commands below at the CloudShell prompt to install
+ElasticBLAST.
+
+.. code-block:: bash
+
+    [ -d .elb-venv ] && rm -fr .elb-venv
+    python3 -m venv .elb-venv
+    source .elb-venv/bin/activate
+    pip install elastic-blast=={VERSION}
+
+
+Following these instructions will add ``elastic-blast``
 to your ``PATH``. If you run into any trouble, please see the
 :ref:`missing_wheel` section.
 

--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -43,17 +43,10 @@ In order to complete this quickstart, you will need to be familiar with the AWS 
 Get ElasticBLAST
 ----------------
 
-Copy and paste the commands below at the CloudShell prompt to install ElasticBLAST.
-
-.. code-block:: shell
-
-    sudo yum install -y python3-wheel
-    sudo pip3 install elastic-blast
-
-
-In some cases (e.g., not on the cloud), it may be preferable to run these commands without using "sudo" (which runs these commands with root permissions).  
-
-The instructions in this quickstart assume that you are working from the directory where you installed ElasticBLAST.
+Please follow the instructions on :ref:`tutorial_pypi` or
+:ref:`tutorial_conda`. Following these instructions will add ``elastic-blast``
+to your ``PATH``. If you run into any trouble, please see the
+:ref:`missing_wheel` section.
 
 Run the two ElasticBLAST commands listed below.  If ElasticBLAST is properly installed, the first one will report the version of ElasticBLAST installed and the second one will give you the help message.
 
@@ -62,7 +55,7 @@ Run the two ElasticBLAST commands listed below.  If ElasticBLAST is properly ins
     elastic-blast --version
     elastic-blast --help
 
-If you are familiar with python, please see :ref:`tutorial_pypi`. Following these instructions will add ``elastic-blast`` to your ``PATH``.
+You may see a message about setuptools replacing distutils, but that can be safely ignored.
 
 Set up an output bucket (if one doesn't exist)
 ----------------------------------------------

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -49,20 +49,10 @@ As you work through this quickstart, you may occasionally see a message from the
 Get ElasticBLAST
 ----------------
 
-Copy and paste the commands below at the Cloud Shell prompt to install ElasticBLAST.
-
-.. code-block:: shell
-
-    sudo apt-get install python-wheel
-    sudo pip3 install --upgrade setuptools
-    sudo pip3 install --upgrade pip
-    sudo pip3 install elastic-blast
-
-You may see a message about setuptools replacing distutils, but that can be safely ignored.
-
-In some cases (e.g., not on the cloud), it may be preferable to run these commands without using "sudo" (which runs these commands with root permissions). 
-
-The instructions in this quickstart assume that you are working from the directory where you installed ElasticBLAST.
+Please follow the instructions on :ref:`tutorial_pypi` or
+:ref:`tutorial_conda`. Following these instructions will add ``elastic-blast``
+to your ``PATH``. If you run into any trouble, please see the
+:ref:`missing_wheel` section.
 
 Run the two ElasticBLAST commands listed below.  If ElasticBLAST is properly installed, the first one will report the version of ElasticBLAST installed and the second one will give you the help message.
 
@@ -71,7 +61,7 @@ Run the two ElasticBLAST commands listed below.  If ElasticBLAST is properly ins
     elastic-blast --version
     elastic-blast --help
 
-If you are familiar with python, please see :ref:`tutorial_pypi`. Following these instructions will add ``elastic-blast`` to your ``PATH``.
+You may see a message about setuptools replacing distutils, but that can be safely ignored.
 
 Set up an output bucket (if one doesn't exist)
 ----------------------------------------------

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -49,8 +49,18 @@ As you work through this quickstart, you may occasionally see a message from the
 Get ElasticBLAST
 ----------------
 
-Please follow the instructions on :ref:`tutorial_pypi` or
-:ref:`tutorial_conda`. Following these instructions will add ``elastic-blast``
+Copy and paste the commands below at the CloudShell prompt to install
+ElasticBLAST.
+
+.. code-block:: bash
+
+    [ -d .elb-venv ] && rm -fr .elb-venv
+    python3 -m venv .elb-venv
+    source .elb-venv/bin/activate
+    pip install elastic-blast=={VERSION}
+
+
+Following these instructions will add ``elastic-blast``
 to your ``PATH``. If you run into any trouble, please see the
 :ref:`missing_wheel` section.
 

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -55,8 +55,8 @@ ElasticBLAST.
 .. code-block:: bash
 
     [ -d .elb-venv ] && rm -fr .elb-venv
-    python3 -m venv .elb-venv
-    source .elb-venv/bin/activate
+    python3 -m venv .elb-venv && source .elb-venv/bin/activate
+    pip install wheel
     pip install elastic-blast=={VERSION}
 
 

--- a/docs/source/tutorials/pypi-install.rst
+++ b/docs/source/tutorials/pypi-install.rst
@@ -30,8 +30,8 @@ Create a new python virtual environment
 
 .. code-block:: bash
 
-    [ -d .elastic-blast-venv ] && rm -fr .elastic-blast-venv
-    python3 -m venv .elastic-blast-venv
+    [ -d .elb-venv ] && rm -fr .elb-venv
+    python3 -m venv .elb-venv
 
 
 Activate the virtual environment
@@ -39,7 +39,7 @@ Activate the virtual environment
 
 .. code-block:: bash
 
-    source .elastic-blast-venv/bin/activate
+    source .elb-venv/bin/activate
 
 Install the latest version of ElasticBLAST
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,14 +69,27 @@ Troubleshooting
 
 If you run into installation problems that mention ``WARNING: The wheel
 package is not available``, please run the command below and kindly re-try
-the installation process.
+installing ``elastic-blast``:
 
 .. code-block:: bash
 
     pip install wheel
+    pip install elastic-blast=={VERSION}
 
-If you run into installation problems on AWS, please run the command below and kindly re-try the installation process.
+If you run into installation problems on the AWS CloudShell, please run the
+commands below and kindly re-try the installation process.
 
 .. code-block:: bash
 
+    deactivate
     sudo yum install -y python3-wheel
+
+If you run into installation problems on the GCP CloudShell, please run the
+commands below and kindly re-try the installation process.
+
+.. code-block:: bash
+
+    deactivate
+    sudo apt-get install -y python-wheel
+    sudo pip3 install --upgrade setuptools
+    sudo pip3 install --upgrade pip


### PR DESCRIPTION
This pull request refers quickstart readers to installation instructions via
PyPI and Bioconda:
<img width="717" alt="Screen Shot 2022-03-02 at 5 07 12 PM" src="https://user-images.githubusercontent.com/736979/156457725-08ea270e-85c0-4372-810d-ab42c94ee1f6.png">

