### PR TITLE
Document gcp-setup-elastic-blast-janitor.sh script to set up GCP janitor

### DIFF
--- a/docs/source/janitor.rst
+++ b/docs/source/janitor.rst
@@ -61,7 +61,10 @@ Please see the `GCP documentation <https://cloud.google.com/sdk/gcloud/reference
 for additional details.
 
 If this operation fails, you may need to ask your GCP account administrator to
-run the aforementioned script on your behalf. 
+run the aforementioned script on your behalf. If this is not possible, setting the
+``ELB_DISABLE_AUTO_SHUTDOWN`` and ``ELB_DISABLE_JOB_SUBMISSION_ON_THE_CLOUD``
+environment variables to any value will disable the auto-shutdown feature.
+
 
 Amazon Web Services (AWS)
 -------------------------

--- a/docs/source/janitor.rst
+++ b/docs/source/janitor.rst
@@ -32,10 +32,38 @@ You only need to do this once per user or service account.
 "elastic-blast delete" to avoid incurring charges after ElasticBLAST
 has completed its operation or failed.**
 
+.. _grant_cluster_admin:
+
 Google Cloud Platform (GCP)
 ---------------------------
 
-Add ``roles/container.admin`` to your :ref:`user or service account <grant_cluster_admin>`.
+This feature requires to have the ``roles/container.admin`` added to your
+user, group, or service account. The script below (provided with ElasticBLAST) 
+can help you set this up. Invoking it as follows will display its online help:
+
+.. code-block:: bash
+
+   gcp-setup-elastic-blast-janitor.sh -h
+
+By default, the script assumes you are using your personal user account, but
+if you are using a service account (e.g.: the output of 
+``gcloud config get-value account`` ends in ``gserviceaccount.com``), you
+will need to specify its ``-u`` argument.  For instance:
+
+.. code-block:: bash
+
+   gcp-setup-elastic-blast-janitor.sh -u serviceAccount:281282530694-compute@developer.gserviceaccount.com
+
+This script is essentially a wrapper around the command ``gcloud projects add-iam-policy-binding``.
+Please see https://cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding
+for its documentation.
+
+If this operation fails, you may need to ask your GCP account administrator to
+run the command on your behalf. If this is not possible, setting the
+``ELB_DISABLE_AUTO_SHUTDOWN`` and ``ELB_DISABLE_JOB_SUBMISSION_ON_THE_CLOUD``
+environment variables to any value will disable
+the auto-shutdown feature and remove the requirement for these additional
+permissions. 
 
 Amazon Web Services (AWS)
 -------------------------

--- a/docs/source/janitor.rst
+++ b/docs/source/janitor.rst
@@ -61,11 +61,7 @@ Please see the `GCP documentation <https://cloud.google.com/sdk/gcloud/reference
 for additional details.
 
 If this operation fails, you may need to ask your GCP account administrator to
-run the command on your behalf. If this is not possible, setting the
-``ELB_DISABLE_AUTO_SHUTDOWN`` and ``ELB_DISABLE_JOB_SUBMISSION_ON_THE_CLOUD``
-environment variables to any value will disable
-the auto-shutdown feature and remove the requirement for these additional
-permissions. 
+run the aforementioned script on your behalf. 
 
 Amazon Web Services (AWS)
 -------------------------

--- a/docs/source/janitor.rst
+++ b/docs/source/janitor.rst
@@ -48,15 +48,17 @@ can help you set this up. Invoking it as follows will display its online help:
 By default, the script assumes you are using your personal user account, but
 if you are using a service account (e.g.: the output of 
 ``gcloud config get-value account`` ends in ``gserviceaccount.com``), you
-will need to specify its ``-u`` argument.  For instance:
+will need to specify its ``-u`` argument.  For instance, invoke the 
+command below replacing ``SVC_ACCT`` with the 
+appropriate value:
 
 .. code-block:: bash
 
-   gcp-setup-elastic-blast-janitor.sh -u serviceAccount:281282530694-compute@developer.gserviceaccount.com
+   gcp-setup-elastic-blast-janitor.sh -u serviceAccount:SVC_ACCT
 
-This script is essentially a wrapper around the command ``gcloud projects add-iam-policy-binding``.
-Please see https://cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding
-for its documentation.
+This script is a wrapper around the command ``gcloud projects add-iam-policy-binding``.
+Please see the `GCP documentation <https://cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding>`_ 
+for additional details.
 
 If this operation fails, you may need to ask your GCP account administrator to
 run the command on your behalf. If this is not possible, setting the

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -261,7 +261,7 @@ account.
     ERROR: The command "kubectl --context=[...] -f/lib/python3.9/site-packages/elastic_blast/templates/elb-janitor-rbac.yaml" returned with exit code 1
     Error from server (Forbidden): error when creating "/lib/python3.9/site-packages/elastic_blast/templates/elb-janitor-rbac.yaml": clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "USERNAME" cannot create resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope: requires one of ["container.clusterRoleBindings.create"] permission(s).
 
-You can grant the :ref:`required permissions using the provided script {{gcp-setup-elastic-blast-janitor.sh}} <grant_cluster_admin>`.
+You can grant the :ref:`required permissions using the provided script <grant_cluster_admin>`.
 
 **Please keep in mind that disabling this feature requires you to invoke
 "elastic-blast delete" to avoid incurring charges after ElasticBLAST

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -252,7 +252,7 @@ Please refer to their respective configuration entries for information on how to
 Cannot create resource "clusterrolebindings"
 --------------------------------------------
 
-If you see the error message below, where ``USERNAME`` is your GCP user or service
+If you see the error message below, where ``USERNAME`` is your GCP user, group, or service
 account name, you need to grant additional permissions to said user/service
 account.
 
@@ -261,20 +261,7 @@ account.
     ERROR: The command "kubectl --context=[...] -f/lib/python3.9/site-packages/elastic_blast/templates/elb-janitor-rbac.yaml" returned with exit code 1
     Error from server (Forbidden): error when creating "/lib/python3.9/site-packages/elastic_blast/templates/elb-janitor-rbac.yaml": clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "USERNAME" cannot create resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope: requires one of ["container.clusterRoleBindings.create"] permission(s).
 
-You can grant the required permissions as shown in the code snippet below. If using a service account,
-please replace ``gcloud config get-value account`` in the command below with
-the service account name (it will look like an email address, likely ending in
-``gserviceaccount.com`` (e.g.: ``281282530694-compute@developer.gserviceaccount.com``).
-
-.. _grant_cluster_admin:
-
-.. code-block:: bash
-
-    gcloud projects add-iam-policy-binding `gcloud config get-value project` --member=`gcloud config get-value account` --role=roles/container.admin
-
-If the command above fails, you may need to ask your GCP account administrator to run the command on your behalf. If this is not possible, 
-setting the ``ELB_DISABLE_AUTO_SHUTDOWN`` environment variable to any value will disable the auto-shutdown feature and
-remove the requirement for these additional permissions. 
+You can grant the :ref:`required permissions using the provided script {{gcp-setup-elastic-blast-janitor.sh}} <grant_cluster_admin>`.
 
 **Please keep in mind that disabling this feature requires you to invoke
 "elastic-blast delete" to avoid incurring charges after ElasticBLAST


### PR DESCRIPTION
- Documentation updates for newly added script gcp-setup-elastic-blast-janitor.sh 
