### PR TITLE
Restore zone and region for GCP quickstart, fix broken links, remove …

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -326,7 +326,7 @@ Cluster configuration
     Format as <number> immediately followed by G for gigabytes, M for megabytes.
 
     **Note**: ElasticBLAST uses ``pd-standard`` block storage by default. Per the
-    `GCP documentation on block storage <https://cloud.google.com/compute/docs/disks/performance#performance_by_disk_size>`_,
+    `GCP documentation on block storage <https://cloud.google.com/compute/docs/disks/performance>`_,
     smaller disks than ``1000G`` result in performance degradation for ElasticBLAST in GCP.
 
     * Default: ``3000G`` for GCP, ``1000G`` for AWS.
@@ -348,7 +348,7 @@ Cluster configuration
     instead of a persistent disk to store BLAST database and query sequence batches.
 
     Consider using this configuration setting if your disk quota is too small
-    (e.g.: 500GB) and it impacts performance (see `GCP documentation on block storage performance <https://cloud.google.com/compute/docs/disks/performance#performance_by_disk_size>`_), but only if the BLAST database
+    (e.g.: 500GB) and it impacts performance (see `GCP documentation on block storage performance <https://cloud.google.com/compute/docs/disks/performance>`_), but only if the BLAST database
     you are searching, your query sequence, and its results can fit into 375GB.
 
     * Default: None

--- a/docs/source/quickstart-aws.rst
+++ b/docs/source/quickstart-aws.rst
@@ -93,7 +93,6 @@ Start by, copying the configuration file shown below.  Using an editor, write th
 
 .. code-block::
     :name: minimal-config
-    :linenos:
 
     [cloud-provider]
     aws-region = us-east-1

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -94,10 +94,11 @@ Start by copying the configuration file shown below.  Using an editor, write thi
 
 .. code-block::
     :name: minimal-config
-    :linenos:
 
     [cloud-provider]
     gcp-project = YOUR_GCP_PROJECT_ID
+    gcp-region = us-east4
+    gcp-zone = us-east4-c
 
     [cluster]
     num-nodes = 6


### PR DESCRIPTION
Changes:

- Fix broken link in configuration section
- Add back zone and region in GCP quickstart (problem encountered by Priyanka)
- remove linenos in the config file example for quickstarts as these numbers got copied into the user config file.

I'm not sure if the last one is new or not but seems like a problem.

This is all for EB-1523