### PR TITLE
1.0.0 release, JIRA:EB-1614

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ html_show_copyright = False
 author = 'Christiam Camacho'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.7'
+release = '1.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -82,9 +82,8 @@ AWS and GCP have programs to award Cloud Credits to researchers at accredited re
 * https://aws.amazon.com/government-education/research-and-technical-computing/cloud-credit-for-research
 * https://edu.google.com/programs/credits/research
 
-Both cloud service providers also have Free Tiers:  
+ElasticBLAST requires an instance with at least 2 GB of memory. GCP has a Free Trial that can be used with ElasticBLAST:
 
-* https://aws.amazon.com/free
-* https://cloud.google.com/free
+At :ref:`gcp_free_trial` we discuss how to use ElasticBLAST under the GCP Free Trial.
 
-While the Free Tiers are a good way to learn about the cloud, they may be too limited for you to effectively use ElasticBLAST. At :ref:`gcp_free_trial` we discuss how to use ElasticBLAST under the GCP Free Trial.
+The Free Trial is a good way to learn about the cloud, but it may be too limited for you to effectively use ElasticBLAST. 

--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -98,16 +98,6 @@ If you do not have a bucket, then you need to make one using the command below.
     gsutil mb gs://elasticblast-${USER}
 
 
-Enable GCP APIs
----------------
-
-You need to enable some GCP API calls that ElasticBLAST needs to make.  This has to be done only once per project.
-
-.. code-block:: shell
-
-    gcloud services enable compute.googleapis.com
-
-
 Enable auto-shutdown feature
 ----------------------------
 
@@ -135,6 +125,8 @@ Start by copying the configuration file shown below.  Using an editor, write thi
     [cluster]
     num-nodes = 1
     labels = owner=USER
+    #Uncomment next line if error "Requested disk size 3000.0G is larger than allowed." occurs.
+    #pd-size = 500G
 
     [blast]
     program = blastp
@@ -170,11 +162,7 @@ Run ElasticBLAST
 The :ref:`submit` command can take a few minutes minutes as it brings up cloud resources and downloads the BLAST database.
 Once it returns, you can move on to the next step.
 
-You may see an error message about your disk size being too large ("Requested disk size 3000.0G is larger than allowed..").  In that case you should add the line below to the [cluster] section of BDQA.ini and retry.
-
-.. code-block::
-
-   pd-size = 500G
+You may see an error message about your disk size being too large ("Requested disk size 3000.0G is larger than allowed..").  In that case you should uncomment the line "pd-size = 500G" line in your config file.  That disk will be large enough for this quick-start.
 
 
 If your cloud shell session disconnects, please see :ref:`cloud_shell_disconnect`.

--- a/docs/source/tips-gcp.rst
+++ b/docs/source/tips-gcp.rst
@@ -59,20 +59,20 @@ GCP has a Free Trial for new users (https://cloud.google.com/free).  The Free Tr
 
 You should be able to run ElasticBLAST under the Free Trial following the instructions at :ref:`quickstart-gcp`, but you will need to modify the configuration file to use fewer resources. You may not be able to use the cloud shell and the instance suggested below as that may exceed the quota on cores allowed at one time.  In that case, you will need to submit your ElasticBLAST search from your own computer.
 
-Fro additional details about GCP's free tier (duration, products included, etc), please visit https://cloud.google.com/free/docs/gcp-free-tier .
+For additional details about GCP's free tier (duration, products included, etc), please visit https://cloud.google.com/free/docs/gcp-free-tier .
 
 Below is a configuration file that should work under the Free Trial as of January 2022.  This file has been modified from the one in :ref:`quickstart-gcp` in the following ways:
 
-* ``num-nodes`` has been set to 1 rather than 2.
 * A ``machine-type``, ``n1-highmem-8``, with 8 CPUs has been specified. Normally, ElasticBLAST automatically sets the machine type based on the size of the database and the program.
 * A persistent disk (``pd-size``) with 200G has been specified.
-* The database is set to swissprot, which is small enough to fit into the memory of the ``n1-highmem-8`` machine.
 
 .. code-block::
     :linenos:
 
     [cloud-provider]
-    gcp-project = YOUR_GCP_PROJECT_ID
+    gcp-region = us-east4
+    gcp-zone = us-east4-b
+
 
     [cluster]
     num-nodes = 1


### PR DESCRIPTION
This branch includes:

- Update revision to 1.0.0
- Change GCP quickstart to remove (no longer necessary) instruction to enable an API
- Change GCP quickstart to add (commented out) pd-size to config file and explain when to use
- Modify Free Trial/Tier to only mention GCP (as AWS machines are too small)