### PR TITLE
Introduce landing page for quickstarts

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ The National Center for Biotechnology Information (`NCBI <https://www.ncbi.nlm.n
 
 **Platforms available:** AWS, GCP (account required)
 
-**Getting started:** Go to the :ref:`overview` or try out a quick-start (:ref:`quickstart-gcp`, :ref:`quickstart-aws`) and then explore the `demos <https://github.com/ncbi/elastic-blast-demos>`_.
+**Getting started:** Go to the :ref:`overview` or try out a :ref:`quickstart` and then explore the `demos <https://github.com/ncbi/elastic-blast-demos>`_.
 
 **Citing ElasticBLAST:**
 
@@ -49,10 +49,9 @@ Camacho C, Boratyn GM, Joukov V, Vera Alvarez R, Madden TL. ElasticBLAST: accele
 
    elasticblast
    overview
-   quickstart-aws
-   quickstart-gcp
-   tutorials
    requirements
+   qstart
+   tutorials
    IAM Policy <iam-policy>
    Budget <budget>
    commands

--- a/docs/source/qstart.rst
+++ b/docs/source/qstart.rst
@@ -1,0 +1,29 @@
+..                           PUBLIC DOMAIN NOTICE
+..              National Center for Biotechnology Information
+..  
+.. This software is a "United States Government Work" under the
+.. terms of the United States Copyright Act.  It was written as part of
+.. the authors' official duties as United States Government employees and
+.. thus cannot be copyrighted.  This software is freely available
+.. to the public for use.  The National Library of Medicine and the U.S.
+.. Government have not placed any restriction on its use or reproduction.
+..   
+.. Although all reasonable efforts have been taken to ensure the accuracy
+.. and reliability of the software and data, the NLM and the U.S.
+.. Government do not and cannot warrant the performance or results that
+.. may be obtained by using this software or data.  The NLM and the U.S.
+.. Government disclaim all warranties, express or implied, including
+.. warranties of performance, merchantability or fitness for any particular
+.. purpose.
+..   
+.. Please cite NCBI in any work or product based on this material.
+
+.. _quickstart:
+
+Quickstart
+==========
+
+Please follow the appropriate link based on the cloud service provider you will use:
+
+* :ref:`quickstart-aws`.
+* :ref:`quickstart-gcp`.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -104,6 +104,7 @@ to grant permissions (see also :ref:`iam-policy`).
 Tutorials
 ^^^^^^^^^
 
+* :ref:`quickstart`
 * :ref:`tutorial_pypi`
 * :ref:`tutorial_conda`
 * :ref:`tutorial_mb`


### PR DESCRIPTION
This pull request adds a single page which links to both GCP and AWS quick starts. This is so that a single link can be provided (e.g.: in social media) to direct users to the quick start. Below are some screenshots:

<img width="1093" alt="Screen Shot 2023-05-16 at 10 28 00 AM" src="https://github.com/ncbi/elastic-blast-docs/assets/736979/216580d9-a9a9-4941-8b2f-06589c02b8da">

<img width="302" alt="Screen Shot 2023-05-16 at 10 34 26 AM" src="https://github.com/ncbi/elastic-blast-docs/assets/736979/29442392-58bd-4fa0-ac4a-b1b16e658af9">

<img width="687" alt="Screen Shot 2023-05-16 at 10 36 16 AM" src="https://github.com/ncbi/elastic-blast-docs/assets/736979/fa38c098-f293-4912-beb9-83aaee4f6c5c">

