### PR TITLE
Another take on ElasticBLAST requirements on GCP

### DIFF
--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -34,11 +34,8 @@ Google Cloud Platform (GCP)
 ---------------------------
 
 * `Google Cloud Command Line Interface <https://cloud.google.com/cli>`_
-* `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl>`_  Make sure to install a version supported by ElasticBLAST:
-
-  * If you are using ElasticBLAST version 1.0.0, please follow the instructions in :ref:`k8s_ver_2023_04`.
-
-* `gke-cloud-auth-plugin <https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke>`_ if you are using ``kubectl`` version 1.26 or later.
+* `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl>`_: Please be sure to install a version supported by GCP (see `this link <https://cloud.google.com/kubernetes-engine/docs/release-notes>`_ for supported versions)
+* `gke-cloud-auth-plugin <https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke>`_
 * You are authenticated, have configured ``gcloud`` with the appropriate GCP
   project, and have the necessary permissions in that GCP project.
   If working on a newly created GCP instance, this likely requires running 


### PR DESCRIPTION
Do not specify versions of kubectl, instead refer users to what GKE supports.