### PR TITLE
Remove k8s version specification from GCP quickstart

### DIFF
--- a/docs/source/quickstart-gcp.rst
+++ b/docs/source/quickstart-gcp.rst
@@ -121,7 +121,6 @@ Start by copying the configuration file shown below.  Using an editor, write thi
     [cloud-provider]
     gcp-region = us-east4
     gcp-zone = us-east4-b
-    gke-version = 1.25
 
     [cluster]
     num-nodes = 1


### PR DESCRIPTION
This will not be needed after ElasticBLAST 1.2.0