### PR TITLE
Update documentation on python requirements

### DIFF
--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -23,7 +23,7 @@
 Requirements
 ============
 
-* `python 3.7 or newer <https://www.python.org/downloads/>`_
+* `python 3.7, 3.8, or 3.9 <https://www.python.org/downloads/>`_
 * ``python3-distutils``
 
 ElasticBLAST has been tested on Linux and macOS. ElasticBLAST on Windows is not


### PR DESCRIPTION
This pull request makes it explicit that only python 3.7, 3.8 and 3.9 are
supported with ElasticBLAST.
